### PR TITLE
Streamlined parsing and enabled answer connversion in cloze format

### DIFF
--- a/exampleQuiz.md
+++ b/exampleQuiz.md
@@ -47,4 +47,21 @@ What type of flow occurs for systems with very high Reynold's numbers.
 
 * Turbulent 
 
+# A cloze Question
+
+## Cloze
+
+This is a cloze question let's see if it works
+
+1. Multiple
+2. Choice
+3. Question
+
+And also a numeric question. How many kittens are there?
+
+* 5 {2} "Correct" #100
+* 12 {4} "So close but no"
+
+There we go
+
 


### PR DESCRIPTION
Separate function was created for parsing answers from numerical, true-false, short answer and multichoice into a dictionary. From their the answers can be converted to either XML or cloze format. Cloze format questions can now contain these kinds of questions in the same format as standalone and will be parsed into the cloze text text format. You can also include the cloze text format directly into the cloze question text.